### PR TITLE
Mention that assets are hosted at mdn.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # MDN shared assets
 
-This repository contains shared media assets for MDN Web Docs including source files where available.
+This repository contains shared media assets for MDN Web Docs, including source files where available.
+
+The assets are hosted at https://mdn.github.io/shared-assets/, so use the `mdn.github.io` URLs in MDN content.
 
 <!--
 


### PR DESCRIPTION
It's better to mention that the assets are hosted. And instead of using GitHub raw URLs the `mdn.github.io` URLs are preferred.